### PR TITLE
feat: add draggable canvas layout for entities

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -158,6 +158,14 @@ button:disabled {
   gap: 1rem;
 }
 
+.canvas__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
 .section-title {
   margin: 0 0 1rem;
   font-size: 1.2rem;
@@ -167,6 +175,119 @@ button:disabled {
 .entities-grid {
   display: grid;
   gap: 1.5rem;
+}
+
+.canvas__board-wrapper {
+  position: relative;
+  flex: 1;
+  min-height: 540px;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.65);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.1);
+  overflow: auto;
+  padding: 2rem;
+}
+
+.canvas-board {
+  position: relative;
+  width: 1600px;
+  height: 960px;
+  min-height: 100%;
+  border-radius: 12px;
+  background-color: rgba(15, 23, 42, 0.85);
+  background-image: radial-gradient(
+    rgba(148, 163, 184, 0.2) 1px,
+    transparent 0
+  );
+  background-size: 48px 48px;
+}
+
+.canvas__status {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 1rem;
+  color: #cbd5f5;
+  text-align: center;
+  pointer-events: none;
+}
+
+.entity-node {
+  position: absolute;
+  width: 260px;
+  min-height: 180px;
+  padding: 1.25rem;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.55);
+  cursor: grab;
+  user-select: none;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.entity-node:active {
+  cursor: grabbing;
+  transform: scale(1.01);
+}
+
+.entity-node__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.entity-node__header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #f8fafc;
+}
+
+.entity-node__attributes {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.entity-node__attributes li {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.entity-node__label {
+  font-weight: 600;
+  color: #cbd5f5;
+  text-transform: capitalize;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.entity-node__value {
+  color: #e2e8f0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: right;
+}
+
+.entity-node__empty {
+  color: #64748b;
+  font-style: italic;
+}
+
+.entity-node__more {
+  color: #94a3b8;
+  font-style: italic;
+  text-align: right;
 }
 
 @media (min-width: 720px) {
@@ -242,6 +363,115 @@ button:disabled {
 .entity-attribute dd {
   margin: 0;
   color: #f8fafc;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.75);
+  backdrop-filter: blur(4px);
+}
+
+.modal__content {
+  position: relative;
+  width: min(520px, 100%);
+  max-height: calc(100vh - 4rem);
+  overflow-y: auto;
+  background: rgba(15, 23, 42, 0.95);
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 28px 48px rgba(15, 23, 42, 0.55);
+}
+
+.modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.5rem 2rem 0;
+}
+
+.modal__header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.modal__body {
+  padding: 1.5rem 2rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+button.modal__close {
+  all: unset;
+  cursor: pointer;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.12);
+  color: #e2e8f0;
+  display: grid;
+  place-items: center;
+  font-size: 1.5rem;
+  line-height: 1;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+button.modal__close:hover {
+  background: rgba(148, 163, 184, 0.2);
+  transform: scale(1.05);
+}
+
+.entity-details {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.entity-details__date {
+  font-size: 0.9rem;
+  color: #94a3b8;
+}
+
+.entity-details__empty {
+  margin: 0;
+  color: #94a3b8;
+  font-style: italic;
+}
+
+.entity-details__list {
+  margin: 0;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.entity-details__item {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.entity-details__item dt {
+  font-weight: 600;
+  text-transform: capitalize;
+  color: #cbd5f5;
+}
+
+.entity-details__item dd {
+  margin: 0;
+  color: #f8fafc;
+  text-align: right;
 }
 
 .attributes {

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useMemo, useState } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+} from "react";
 import { useAuth } from "../context/AuthContext";
 import {
   createEntity,
@@ -19,6 +27,11 @@ type AttributeField = {
   value: string;
 };
 
+type CanvasPosition = {
+  x: number;
+  y: number;
+};
+
 const ENTITY_TYPES = [
   "CHARACTER",
   "LOCATION",
@@ -31,6 +44,9 @@ const createId = () =>
   typeof crypto !== "undefined" && "randomUUID" in crypto
     ? crypto.randomUUID()
     : Math.random().toString(36).slice(2);
+
+const CARD_WIDTH = 260;
+const CARD_HEIGHT = 180;
 
 export function CanvasPage({ world, onBack }: CanvasPageProps) {
   const { token } = useAuth();
@@ -46,6 +62,15 @@ export function CanvasPage({ world, onBack }: CanvasPageProps) {
     { id: createId(), key: "", value: "" },
   ]);
   const [isCreating, setIsCreating] = useState(false);
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [selectedEntity, setSelectedEntity] = useState<Entity | null>(null);
+  const [positions, setPositions] = useState<Record<string, CanvasPosition>>({});
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const canvasRef = useRef<HTMLDivElement | null>(null);
+  const dragOffsetRef = useRef<CanvasPosition>({ x: 0, y: 0 });
+  const dragMovedRef = useRef(false);
+  const pointerIdRef = useRef<number | null>(null);
+  const dragTargetRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     const loadEntities = async () => {
@@ -119,6 +144,7 @@ export function CanvasPage({ world, onBack }: CanvasPageProps) {
       setEntities((prev) => [newEntity, ...prev]);
       setForm({ name: "", entity_type: ENTITY_TYPES[0], attributes: {} });
       setAttributeFields([{ id: createId(), key: "", value: "" }]);
+      setIsCreateModalOpen(false);
     } catch (err) {
       if (err instanceof Error) {
         setError(err.message);
@@ -138,113 +164,329 @@ export function CanvasPage({ world, onBack }: CanvasPageProps) {
     [entities]
   );
 
+  useEffect(() => {
+    setPositions((prev) => {
+      const next = { ...prev };
+      let changed = false;
+      const existingIds = new Set<string>();
+
+      orderedEntities.forEach((entity, index) => {
+        existingIds.add(entity.id);
+        if (!next[entity.id]) {
+          const column = index % 4;
+          const row = Math.floor(index / 4);
+          next[entity.id] = {
+            x: 120 + column * 280,
+            y: 120 + row * 220,
+          };
+          changed = true;
+        }
+      });
+
+      Object.keys(next).forEach((id) => {
+        if (!existingIds.has(id)) {
+          delete next[id];
+          changed = true;
+        }
+      });
+
+      return changed ? next : prev;
+    });
+  }, [orderedEntities]);
+
+  useEffect(() => {
+    if (!draggingId) return;
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+
+      event.preventDefault();
+
+      const rect = canvas.getBoundingClientRect();
+      const rawX = event.clientX - rect.left - dragOffsetRef.current.x;
+      const rawY = event.clientY - rect.top - dragOffsetRef.current.y;
+      const maxX = Math.max(0, canvas.clientWidth - CARD_WIDTH);
+      const maxY = Math.max(0, canvas.clientHeight - CARD_HEIGHT);
+
+      setPositions((prev) => ({
+        ...prev,
+        [draggingId]: {
+          x: Math.min(Math.max(0, rawX), maxX),
+          y: Math.min(Math.max(0, rawY), maxY),
+        },
+      }));
+
+      if (
+        !dragMovedRef.current &&
+        (Math.abs(event.movementX) > 1 || Math.abs(event.movementY) > 1)
+      ) {
+        dragMovedRef.current = true;
+      }
+    };
+
+    const handlePointerUp = () => {
+      setDraggingId(null);
+      if (pointerIdRef.current !== null && dragTargetRef.current) {
+        dragTargetRef.current.releasePointerCapture?.(pointerIdRef.current);
+      }
+      pointerIdRef.current = null;
+      dragTargetRef.current = null;
+      setTimeout(() => {
+        dragMovedRef.current = false;
+      }, 0);
+    };
+
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp);
+
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
+    };
+  }, [draggingId]);
+
+  useEffect(() => {
+    if (!isCreateModalOpen && !selectedEntity) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setSelectedEntity(null);
+        setIsCreateModalOpen(false);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isCreateModalOpen, selectedEntity]);
+
+  const handlePointerDown = (
+    event: ReactPointerEvent<HTMLElement>,
+    entityId: string
+  ) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const rect = canvas.getBoundingClientRect();
+    const currentPosition = positions[entityId] ?? { x: 0, y: 0 };
+    dragOffsetRef.current = {
+      x: event.clientX - rect.left - currentPosition.x,
+      y: event.clientY - rect.top - currentPosition.y,
+    };
+
+    dragTargetRef.current = event.currentTarget as HTMLElement;
+    pointerIdRef.current = event.pointerId;
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    dragMovedRef.current = false;
+    setDraggingId(entityId);
+    event.stopPropagation();
+    event.preventDefault();
+  };
+
+  const handleEntityClick = (
+    event: ReactMouseEvent<HTMLElement>,
+    entity: Entity
+  ) => {
+    event.stopPropagation();
+    if (dragMovedRef.current) {
+      dragMovedRef.current = false;
+      return;
+    }
+    setSelectedEntity(entity);
+  };
+
   return (
     <div className="canvas">
       <header className="canvas__header">
-        <button className="secondary" type="button" onClick={onBack}>
-          Voltar
-        </button>
         <div>
           <h1 className="title">{world.name}</h1>
           <p className="subtitle">{world.description || "Sem descrição"}</p>
         </div>
+        <div className="canvas__actions">
+          <button className="secondary" type="button" onClick={onBack}>
+            Voltar
+          </button>
+          <button type="button" onClick={() => setIsCreateModalOpen(true)}>
+            Nova entidade
+          </button>
+        </div>
       </header>
 
-      <section className="card">
-        <h2 className="section-title">Nova entidade</h2>
-        <form className="form" onSubmit={handleCreateEntity}>
-          <label className="field">
-            <span>Nome</span>
-            <input
-              name="name"
-              value={form.name}
-              onChange={handleFormChange}
-              required
-              placeholder="Ex.: Naoyia Satoshi"
-            />
-          </label>
-          <label className="field">
-            <span>Tipo</span>
-            <select
-              name="entity_type"
-              value={form.entity_type}
-              onChange={handleFormChange}
-            >
-              {ENTITY_TYPES.map((type) => (
-                <option key={type} value={type}>
-                  {type}
-                </option>
-              ))}
-            </select>
-          </label>
-
-          <div className="attributes">
-            <span className="attributes__title">Atributos</span>
-            {attributeFields.map((field) => (
-              <div key={field.id} className="attributes__row">
-                <input
-                  placeholder="Chave (ex.: hair)"
-                  value={field.key}
-                  onChange={(event) =>
-                    handleAttributeChange(field.id, "key", event.target.value)
-                  }
-                />
-                <input
-                  placeholder="Valor (ex.: white)"
-                  value={field.value}
-                  onChange={(event) =>
-                    handleAttributeChange(field.id, "value", event.target.value)
-                  }
-                />
-                <button
-                  type="button"
-                  className="danger"
-                  onClick={() => handleRemoveAttribute(field.id)}
-                  disabled={attributeFields.length === 1}
-                >
-                  Remover
-                </button>
-              </div>
-            ))}
-            <button
-              type="button"
-              className="secondary"
-              onClick={handleAddAttribute}
-            >
-              Adicionar atributo
-            </button>
-          </div>
-
-          <button type="submit" disabled={isCreating}>
-            {isCreating ? "Criando..." : "Criar entidade"}
-          </button>
-        </form>
-      </section>
-
       {error && <p className="error">{error}</p>}
+      <div className="canvas__board-wrapper">
+        <div className="canvas-board" ref={canvasRef}>
+          {isLoading && (
+            <p className="canvas__status">Carregando entidades...</p>
+          )}
+          {!isLoading && orderedEntities.length === 0 && (
+            <p className="canvas__status">Nenhuma entidade criada ainda.</p>
+          )}
+          {orderedEntities.map((entity) => {
+            const position = positions[entity.id] ?? { x: 120, y: 120 };
+            const entries = Object.entries(entity.attributes ?? {});
+            const preview = entries.slice(0, 2);
+            return (
+              <article
+                key={entity.id}
+                className="entity-node"
+                style={{ left: position.x, top: position.y }}
+                onPointerDown={(event) => handlePointerDown(event, entity.id)}
+                onClick={(event) => handleEntityClick(event, entity)}
+              >
+                <header className="entity-node__header">
+                  <h3>{entity.name}</h3>
+                  <span className="entity-type">{entity.entity_type}</span>
+                </header>
+                <ul className="entity-node__attributes">
+                  {preview.map(([key, value]) => (
+                    <li key={key}>
+                      <span className="entity-node__label">{key}</span>
+                      <span className="entity-node__value">{value}</span>
+                    </li>
+                  ))}
+                  {entries.length === 0 && (
+                    <li className="entity-node__empty">Sem atributos</li>
+                  )}
+                  {entries.length > preview.length && (
+                    <li className="entity-node__more">
+                      +{entries.length - preview.length} atributos
+                    </li>
+                  )}
+                </ul>
+              </article>
+            );
+          })}
+        </div>
+      </div>
 
-      <section className="entities-grid">
-        {isLoading && <p className="loading">Carregando entidades...</p>}
-        {!isLoading && orderedEntities.length === 0 && (
-          <p className="empty">Nenhuma entidade criada ainda.</p>
-        )}
-        {orderedEntities.map((entity) => (
-          <article key={entity.id} className="entity-card">
-            <header>
-              <h3>{entity.name}</h3>
-              <span className="entity-type">{entity.entity_type}</span>
-            </header>
-            <dl>
-              {Object.entries(entity.attributes ?? {}).map(([key, value]) => (
-                <div key={key} className="entity-attribute">
-                  <dt>{key}</dt>
-                  <dd>{value}</dd>
+      {isCreateModalOpen && (
+        <Modal title="Criar nova entidade" onClose={() => setIsCreateModalOpen(false)}>
+          <form className="form" onSubmit={handleCreateEntity}>
+            <label className="field">
+              <span>Nome</span>
+              <input
+                name="name"
+                value={form.name}
+                onChange={handleFormChange}
+                required
+                placeholder="Ex.: Naoyia Satoshi"
+              />
+            </label>
+            <label className="field">
+              <span>Tipo</span>
+              <select
+                name="entity_type"
+                value={form.entity_type}
+                onChange={handleFormChange}
+              >
+                {ENTITY_TYPES.map((type) => (
+                  <option key={type} value={type}>
+                    {type}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <div className="attributes">
+              <span className="attributes__title">Atributos</span>
+              {attributeFields.map((field) => (
+                <div key={field.id} className="attributes__row">
+                  <input
+                    placeholder="Chave (ex.: hair)"
+                    value={field.key}
+                    onChange={(event) =>
+                      handleAttributeChange(field.id, "key", event.target.value)
+                    }
+                  />
+                  <input
+                    placeholder="Valor (ex.: white)"
+                    value={field.value}
+                    onChange={(event) =>
+                      handleAttributeChange(field.id, "value", event.target.value)
+                    }
+                  />
+                  <button
+                    type="button"
+                    className="danger"
+                    onClick={() => handleRemoveAttribute(field.id)}
+                    disabled={attributeFields.length === 1}
+                  >
+                    Remover
+                  </button>
                 </div>
               ))}
-            </dl>
-          </article>
-        ))}
-      </section>
+              <button
+                type="button"
+                className="secondary"
+                onClick={handleAddAttribute}
+              >
+                Adicionar atributo
+              </button>
+            </div>
+
+            <button type="submit" disabled={isCreating}>
+              {isCreating ? "Criando..." : "Criar entidade"}
+            </button>
+          </form>
+        </Modal>
+      )}
+
+      {selectedEntity && (
+        <Modal
+          title={selectedEntity.name}
+          onClose={() => setSelectedEntity(null)}
+        >
+          <div className="entity-details">
+            <span className="entity-type">{selectedEntity.entity_type}</span>
+            <span className="entity-details__date">
+              Criado em {" "}
+              {new Date(selectedEntity.created_at).toLocaleDateString()}
+            </span>
+            {Object.keys(selectedEntity.attributes ?? {}).length === 0 ? (
+              <p className="entity-details__empty">Sem atributos cadastrados.</p>
+            ) : (
+              <dl className="entity-details__list">
+                {Object.entries(selectedEntity.attributes ?? {}).map(
+                  ([key, value]) => (
+                    <div key={key} className="entity-details__item">
+                      <dt>{key}</dt>
+                      <dd>{value}</dd>
+                    </div>
+                  )
+                )}
+              </dl>
+            )}
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}
+
+type ModalProps = {
+  title: string;
+  onClose: () => void;
+  children: ReactNode;
+};
+
+function Modal({ title, onClose, children }: ModalProps) {
+  return (
+    <div className="modal" role="dialog" aria-modal="true">
+      <div className="modal__backdrop" onClick={onClose} />
+      <div className="modal__content">
+        <header className="modal__header">
+          <h2>{title}</h2>
+          <button
+            type="button"
+            className="modal__close"
+            onClick={onClose}
+            aria-label="Fechar modal"
+          >
+            ×
+          </button>
+        </header>
+        <div className="modal__body">{children}</div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace the entity grid with a draggable canvas so cards can be positioned freely
- show entity details in a modal and move the creation form to a modal that opens from a button
- add styling for the canvas surface, draggable cards, and shared modal layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e28fa9abd88325af785a50a5a9b7f5