### PR TITLE
Add entity update workflows to canvas page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -564,7 +564,7 @@ button:disabled {
 
 .modal__content {
   position: relative;
-  width: min(520px, 100%);
+  width: min(760px, 100%);
   max-height: calc(100vh - 4rem);
   overflow-y: auto;
   background: rgba(15, 23, 42, 0.95);
@@ -617,6 +617,152 @@ button.modal__close:hover {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+.entity-details__error {
+  margin: 0;
+  color: #fca5a5;
+  font-size: 0.9rem;
+}
+
+.entity-edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  padding: 1rem 1.25rem;
+  border-radius: 14px;
+  background: rgba(148, 163, 184, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.entity-edit-form__grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 640px) {
+  .entity-edit-form__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.entity-edit-form__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.9rem;
+}
+
+.entity-edit-form__type-badge {
+  font-size: 0.8rem;
+}
+
+.entity-edit-form__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.entity-attributes-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.25rem 1.25rem 1.4rem;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.entity-attributes-form__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.entity-attributes-form__header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.entity-attributes-form__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.entity-attributes-form__empty {
+  margin: 0;
+}
+
+.entity-attributes-form__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.attribute-edit-field {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1rem 1.1rem;
+  border-radius: 12px;
+  background: rgba(148, 163, 184, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.attribute-edit-field__inputs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  flex: 1 1 100%;
+}
+
+.attribute-edit-field__inputs label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  flex: 1 1 220px;
+  font-size: 0.9rem;
+}
+
+.attribute-edit-field__value {
+  flex: 2 1 280px;
+}
+
+.attribute-edit-field__inputs input,
+.attribute-edit-field__value input,
+.attribute-edit-field__value textarea {
+  width: 100%;
+  padding: 0.6rem 0.8rem;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.65);
+  color: inherit;
+}
+
+.attribute-edit-field__value textarea {
+  resize: vertical;
+  min-height: 96px;
+  line-height: 1.4;
+}
+
+.attribute-edit-field__value.attribute-edit-field__value--expanded textarea {
+  min-height: 140px;
+}
+
+.attribute-edit-field--stacked .attribute-edit-field__inputs {
+  flex-direction: column;
+}
+
+.attribute-edit-field--stacked .attribute-edit-field__value {
+  flex: 1 1 100%;
+}
+
+.attribute-edit-field button.danger {
+  align-self: flex-end;
+  white-space: nowrap;
 }
 
 .entity-details__date {

--- a/src/api/worlds.ts
+++ b/src/api/worlds.ts
@@ -34,6 +34,15 @@ export type EntityPayload = {
   attributes: Record<string, string>;
 };
 
+export type UpdateEntityPayload = {
+  name?: string;
+  entity_type?: string;
+};
+
+export type UpdateEntityAttributesPayload = {
+  attributes: Record<string, string>;
+};
+
 export type EntityRelationPayload = {
   targetEntityId: string;
   type: EntityRelationType;
@@ -108,6 +117,34 @@ export async function createEntityRelation(
 ): Promise<Entity> {
   const { data } = await axios.post<Entity>(
     `${BASE_URL}/worlds/${worldId}/entities/${entityId}/relations`,
+    payload,
+    authHeader(token)
+  );
+  return data;
+}
+
+export async function updateEntity(
+  token: string,
+  worldId: string,
+  entityId: string,
+  payload: UpdateEntityPayload
+): Promise<Entity> {
+  const { data } = await axios.patch<Entity>(
+    `${BASE_URL}/worlds/${worldId}/entities/${entityId}`,
+    payload,
+    authHeader(token)
+  );
+  return data;
+}
+
+export async function updateEntityAttributes(
+  token: string,
+  worldId: string,
+  entityId: string,
+  payload: UpdateEntityAttributesPayload
+): Promise<Entity> {
+  const { data } = await axios.patch<Entity>(
+    `${BASE_URL}/worlds/${worldId}/entities/${entityId}/attributes`,
     payload,
     authHeader(token)
   );


### PR DESCRIPTION
## Summary
- add client helpers for the new entity PATCH endpoints
- enable editing entity details and attributes from the canvas modal with long-text handling
- widen and restyle the entity modal to accommodate the new forms

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3c417f4608325ab8588a3d85e07e9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Edit existing entities directly in the modal: update name/type and modify attributes.
  - Add or remove attributes with dynamic rows; long values automatically use an expanded textarea for easier editing.
  - Streamlined create flow with clearer attribute handling and resets after creation.

- Style
  - Wider modal for improved readability.
  - New responsive layouts for entity and attribute forms, with refined input and action button styling for a cleaner, more usable editor experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->