### PR TITLE
Implement routing with landing page and refreshed canvas styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,6 +14,96 @@
   min-height: 100vh;
 }
 
+.landing {
+  width: min(960px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+  text-align: left;
+}
+
+.landing__header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  background: linear-gradient(160deg, rgba(30, 64, 175, 0.25), rgba(56, 189, 248, 0.18));
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 24px;
+  padding: 2.75rem 3rem;
+  box-shadow: 0 32px 70px rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(14px);
+}
+
+.landing__badge {
+  align-self: flex-start;
+  padding: 0.3rem 1rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.15);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #cbd5f5;
+}
+
+.landing h1 {
+  margin: 0;
+  font-size: clamp(2.5rem, 5vw, 3.25rem);
+  line-height: 1.1;
+  color: #f8fafc;
+}
+
+.landing__header p {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #d6e3ff;
+  max-width: 48ch;
+}
+
+.landing__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.landing__actions button {
+  flex-shrink: 0;
+}
+
+.landing__highlights {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .landing__highlights {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.landing__highlights article {
+  background: rgba(15, 23, 42, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 18px;
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.4);
+}
+
+.landing__highlights h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #f8fafc;
+}
+
+.landing__highlights p {
+  margin: 0;
+  color: #cbd5f5;
+  line-height: 1.45;
+}
+
 .auth-card,
 .card {
   background: rgba(15, 23, 42, 0.85);
@@ -126,6 +216,57 @@ button:disabled {
   border: 1px solid rgba(239, 68, 68, 0.35);
 }
 
+.button-with-icon {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.button-with-icon svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.icon-button {
+  border-radius: 0.75rem;
+  padding: 0;
+  width: 2.35rem;
+  height: 2.35rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(148, 163, 184, 0.12);
+  color: #e2e8f0;
+  transition: transform 0.2s ease, background 0.2s ease, filter 0.2s ease;
+}
+
+.icon-button svg {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.icon-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  background: rgba(148, 163, 184, 0.2);
+}
+
+.icon-button:disabled {
+  opacity: 0.55;
+}
+
+.icon-button--danger {
+  background: rgba(239, 68, 68, 0.12);
+  border-color: rgba(239, 68, 68, 0.35);
+  color: #fecaca;
+}
+
+.icon-button--accent {
+  background: rgba(56, 189, 248, 0.12);
+  border-color: rgba(56, 189, 248, 0.35);
+  color: #bae6fd;
+}
+
 .link-button {
   margin-top: 1.5rem;
   background: none;
@@ -149,6 +290,30 @@ button:disabled {
   color: #4ade80;
 }
 
+.not-found {
+  width: min(520px, 100%);
+  background: rgba(15, 23, 42, 0.88);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 24px;
+  padding: 2.5rem 3rem;
+  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.5);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  text-align: center;
+}
+
+.not-found h1 {
+  margin: 0;
+  font-size: 2rem;
+  color: #f8fafc;
+}
+
+.not-found p {
+  margin: 0;
+  color: #cbd5f5;
+}
+
 
 .dashboard {
   width: min(960px, 100%);
@@ -166,6 +331,14 @@ button:disabled {
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
+}
+
+.dashboard__header--worlds {
+  background: linear-gradient(160deg, rgba(29, 78, 216, 0.18), rgba(56, 189, 248, 0.12));
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  padding: 1.75rem 2.25rem;
+  border-radius: 22px;
+  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.45);
 }
 
 .canvas__actions {
@@ -199,8 +372,8 @@ button:disabled {
   flex-direction: column;
   gap: 1.5rem;
   padding: 2.5rem 2rem;
-  border-right: 1px solid rgba(148, 163, 184, 0.15);
-  background: rgba(15, 23, 42, 0.82);
+  border-right: 1px solid rgba(148, 163, 184, 0.12);
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.9), rgba(30, 64, 175, 0.18));
   backdrop-filter: blur(14px);
 }
 
@@ -211,13 +384,27 @@ button:disabled {
 }
 
 .canvas__sidebar-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
   align-self: flex-start;
+  padding-inline: 1.1rem;
+}
+
+.canvas__sidebar-back svg {
+  width: 1.1rem;
+  height: 1.1rem;
 }
 
 .canvas__sidebar-actions {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.canvas__sidebar-error {
+  margin: 0;
 }
 
 .canvas__surface {
@@ -301,15 +488,55 @@ button:disabled {
   pointer-events: none;
 }
 
+.canvas--feedback {
+  display: grid;
+  place-items: center;
+  background: linear-gradient(160deg, #0b1120 0%, #111c2f 100%);
+  min-height: 100vh;
+}
+
+.canvas__feedback-card {
+  background: rgba(15, 23, 42, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 20px;
+  padding: 2.5rem 3rem;
+  max-width: 420px;
+  text-align: center;
+  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.canvas__feedback-card h1 {
+  margin: 0;
+  font-size: 1.8rem;
+  color: #f8fafc;
+}
+
+.canvas__feedback-card p {
+  margin: 0;
+  color: #cbd5f5;
+}
+
 .entity-node {
   position: absolute;
   width: 260px;
   min-height: 180px;
   padding: 1.25rem;
   border-radius: 18px;
-  background: rgba(15, 23, 42, 0.92);
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.55);
+  background: linear-gradient(
+      155deg,
+      rgba(15, 23, 42, 0.96),
+      rgba(15, 23, 42, 0.9)
+    ),
+    radial-gradient(
+      circle at top left,
+      var(--entity-color-soft, rgba(56, 189, 248, 0.12)),
+      transparent 60%
+    );
+  border: 1px solid var(--entity-color-strong, rgba(148, 163, 184, 0.35));
+  box-shadow: 0 22px 45px var(--entity-color-soft, rgba(15, 23, 42, 0.55));
   cursor: grab;
   user-select: none;
   transition: box-shadow 0.2s ease, transform 0.2s ease;
@@ -333,6 +560,10 @@ button:disabled {
   margin: 0;
   font-size: 1.1rem;
   color: #f8fafc;
+  max-width: 70%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .entity-node__attributes {
@@ -346,6 +577,7 @@ button:disabled {
 .entity-node__attributes li {
   display: flex;
   justify-content: space-between;
+  align-items: flex-start;
   gap: 0.5rem;
   font-size: 0.85rem;
 }
@@ -356,15 +588,26 @@ button:disabled {
   text-transform: capitalize;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: normal;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  line-height: 1.25;
+  max-width: 45%;
 }
 
 .entity-node__value {
   color: #e2e8f0;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: normal;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  line-height: 1.3;
   text-align: right;
+  max-width: 55%;
+  word-break: break-word;
 }
 
 .entity-node__empty {
@@ -487,6 +730,24 @@ button:disabled {
   padding: 1.5rem;
   border: 1px solid rgba(148, 163, 184, 0.2);
   box-shadow: 0 12px 32px rgba(15, 23, 42, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.card--highlight {
+  background: linear-gradient(160deg, rgba(56, 189, 248, 0.08), rgba(99, 102, 241, 0.12));
+  border-color: rgba(148, 163, 184, 0.32);
+}
+
+.world-card--accent {
+  background: linear-gradient(170deg, rgba(30, 64, 175, 0.18), rgba(15, 23, 42, 0.88));
+  border: 1px solid rgba(56, 189, 248, 0.28);
+  box-shadow: 0 24px 55px rgba(15, 23, 42, 0.45);
+}
+
+.world-card--accent button {
+  align-self: flex-start;
 }
 
 .world-card header,
@@ -513,12 +774,13 @@ button:disabled {
 }
 
 .entity-type {
-  background: rgba(56, 189, 248, 0.12);
-  color: #38bdf8;
+  background: var(--entity-color-soft, rgba(56, 189, 248, 0.15));
+  color: var(--entity-color, #38bdf8);
   padding: 0.2rem 0.7rem;
   border-radius: 999px;
   font-size: 0.8rem;
   font-weight: 600;
+  border: 1px solid var(--entity-color-strong, rgba(56, 189, 248, 0.35));
 }
 
 .entity-card dl {
@@ -593,24 +855,14 @@ button:disabled {
   gap: 1.5rem;
 }
 
-button.modal__close {
-  all: unset;
-  cursor: pointer;
-  width: 2.25rem;
-  height: 2.25rem;
-  border-radius: 999px;
-  background: rgba(148, 163, 184, 0.12);
-  color: #e2e8f0;
-  display: grid;
-  place-items: center;
-  font-size: 1.5rem;
-  line-height: 1;
-  transition: background 0.2s ease, transform 0.2s ease;
+.modal__close {
+  background: rgba(148, 163, 184, 0.14);
+  border-color: rgba(148, 163, 184, 0.35);
 }
 
-button.modal__close:hover {
-  background: rgba(148, 163, 184, 0.2);
-  transform: scale(1.05);
+.modal__close:hover:not(:disabled) {
+  background: rgba(148, 163, 184, 0.24);
+  transform: translateY(-1px);
 }
 
 .entity-details {
@@ -760,9 +1012,8 @@ button.modal__close:hover {
   flex: 1 1 100%;
 }
 
-.attribute-edit-field button.danger {
+.attribute-edit-field .icon-button {
   align-self: flex-end;
-  white-space: nowrap;
 }
 
 .entity-details__date {
@@ -824,7 +1075,7 @@ button.modal__close:hover {
   .attributes__row {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
-  .attributes__row button {
+  .attributes__row .icon-button {
     justify-self: start;
     align-self: center;
   }

--- a/src/api/worlds.ts
+++ b/src/api/worlds.ts
@@ -73,6 +73,17 @@ export async function fetchWorlds(token: string): Promise<World[]> {
   return data;
 }
 
+export async function fetchWorld(
+  token: string,
+  worldId: string
+): Promise<World> {
+  const { data } = await axios.get<World>(
+    `${BASE_URL}/worlds/${worldId}`,
+    authHeader(token)
+  );
+  return data;
+}
+
 export async function createWorld(
   token: string,
   payload: WorldPayload

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,0 +1,33 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
+type IconButtonProps = {
+  label: string;
+  icon: ReactNode;
+  variant?: "ghost" | "danger" | "accent";
+} & ButtonHTMLAttributes<HTMLButtonElement>;
+
+export function IconButton({
+  label,
+  icon,
+  variant = "ghost",
+  className,
+  type = "button",
+  ...props
+}: IconButtonProps) {
+  const classes = ["icon-button", `icon-button--${variant}`];
+  if (className) {
+    classes.push(className);
+  }
+
+  return (
+    <button
+      type={type}
+      className={classes.join(" ")}
+      aria-label={label}
+      title={label}
+      {...props}
+    >
+      {icon}
+    </button>
+  );
+}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from "react";
+import { IconButton } from "./IconButton";
+
+type ModalProps = {
+  title: string;
+  onClose: () => void;
+  children: ReactNode;
+};
+
+function CloseIcon() {
+  return (
+    <svg
+      width={18}
+      height={18}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  );
+}
+
+export function Modal({ title, onClose, children }: ModalProps) {
+  return (
+    <div className="modal" role="dialog" aria-modal="true">
+      <div className="modal__backdrop" onClick={onClose} />
+      <div className="modal__content">
+        <header className="modal__header">
+          <h2>{title}</h2>
+          <IconButton
+            label="Fechar modal"
+            onClick={onClose}
+            className="modal__close"
+            icon={<CloseIcon />}
+          />
+        </header>
+        <div className="modal__body">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,14 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App";
 import { AuthProvider } from "./context/AuthContext";
+import { RouterProvider } from "./router/RouterProvider";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <AuthProvider>
-      <App />
+      <RouterProvider>
+        <App />
+      </RouterProvider>
     </AuthProvider>
   </StrictMode>
 );

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,0 +1,62 @@
+import { useAuth } from "../context/AuthContext";
+import { useRouter } from "../router/RouterProvider";
+
+export function LandingPage() {
+  const { isAuthenticated } = useAuth();
+  const { navigate } = useRouter();
+
+  const handlePrimaryAction = () => {
+    navigate(isAuthenticated ? "/worlds" : "/login");
+  };
+
+  return (
+    <div className="landing">
+      <header className="landing__header">
+        <span className="landing__badge">World Forge</span>
+        <h1>Organize histórias e universos de forma visual</h1>
+        <p>
+          Crie mundos, conecte personagens, itens e organizações com um quadro
+          visual poderoso. Explore relações, documente detalhes e mantenha todo
+          o seu universo em um só lugar.
+        </p>
+      </header>
+
+      <div className="landing__actions">
+        <button type="button" onClick={handlePrimaryAction}>
+          {isAuthenticated ? "Ir para meus mundos" : "Entrar"}
+        </button>
+        <button
+          type="button"
+          className="secondary"
+          onClick={() => navigate("/register")}
+        >
+          Criar conta gratuita
+        </button>
+      </div>
+
+      <section className="landing__highlights">
+        <article>
+          <h2>Construa universos conectados</h2>
+          <p>
+            Cadastre entidades com atributos ricos e visualize as conexões entre
+            elas em tempo real.
+          </p>
+        </article>
+        <article>
+          <h2>Controle total das relações</h2>
+          <p>
+            Defina origens, alianças, rivalidades e muito mais com alguns cliques
+            em um ambiente intuitivo.
+          </p>
+        </article>
+        <article>
+          <h2>Foque no que importa</h2>
+          <p>
+            Um visual moderno e minimalista ajuda você a navegar pelos detalhes
+            sem perder o contexto do seu mundo.
+          </p>
+        </article>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,17 +1,28 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useAuth } from "../context/AuthContext";
+import { useRouter } from "../router/RouterProvider";
 
-type LoginPageProps = {
-  onGoToRegister: () => void;
-  onSuccess: () => void;
+type LoginState = {
+  from?: string;
 };
 
-export function LoginPage({ onGoToRegister, onSuccess }: LoginPageProps) {
+export function LoginPage() {
   const { login } = useAuth();
+  const { navigate, state } = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const redirectPath = useMemo(() => {
+    if (state && typeof state === "object") {
+      const potentialState = state as LoginState;
+      if (potentialState.from) {
+        return potentialState.from;
+      }
+    }
+    return "/worlds";
+  }, [state]);
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -19,7 +30,7 @@ export function LoginPage({ onGoToRegister, onSuccess }: LoginPageProps) {
     setIsSubmitting(true);
     try {
       await login(email, password);
-      onSuccess();
+      navigate(redirectPath, { replace: true });
     } catch (err) {
       if (err instanceof Error) {
         setError(err.message);
@@ -59,7 +70,11 @@ export function LoginPage({ onGoToRegister, onSuccess }: LoginPageProps) {
           {isSubmitting ? "Entrando..." : "Entrar"}
         </button>
       </form>
-      <button className="link-button" type="button" onClick={onGoToRegister}>
+      <button
+        className="link-button"
+        type="button"
+        onClick={() => navigate("/register")}
+      >
         Criar uma conta
       </button>
     </div>

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -1,26 +1,25 @@
 import { useState } from "react";
 import { useAuth } from "../context/AuthContext";
+import { useRouter } from "../router/RouterProvider";
 
-type RegisterPageProps = {
-  onGoToLogin: () => void;
-  onRegistered: () => void;
-};
-
-export function RegisterPage({ onGoToLogin, onRegistered }: RegisterPageProps) {
+export function RegisterPage() {
   const { register } = useAuth();
+  const { navigate } = useRouter();
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
     setError(null);
+    setSuccessMessage(null);
     setIsSubmitting(true);
     try {
       await register(username, email, password);
-      onRegistered();
+      setSuccessMessage("Conta criada com sucesso! Faça login para continuar.");
     } catch (err) {
       if (err instanceof Error) {
         setError(err.message);
@@ -65,11 +64,16 @@ export function RegisterPage({ onGoToLogin, onRegistered }: RegisterPageProps) {
           />
         </label>
         {error && <p className="error">{error}</p>}
+        {successMessage && <p className="success">{successMessage}</p>}
         <button type="submit" disabled={isSubmitting}>
           {isSubmitting ? "Criando conta..." : "Registrar"}
         </button>
       </form>
-      <button className="link-button" type="button" onClick={onGoToLogin}>
+      <button
+        className="link-button"
+        type="button"
+        onClick={() => navigate("/login")}
+      >
         Já tenho uma conta
       </button>
     </div>

--- a/src/pages/WorldsPage.tsx
+++ b/src/pages/WorldsPage.tsx
@@ -6,13 +6,11 @@ import {
   type World,
   type WorldPayload,
 } from "../api/worlds";
+import { useRouter } from "../router/RouterProvider";
 
-type WorldsPageProps = {
-  onOpenWorld: (world: World) => void;
-};
-
-export function WorldsPage({ onOpenWorld }: WorldsPageProps) {
+export function WorldsPage() {
   const { token, logout } = useAuth();
+  const { navigate } = useRouter();
   const [worlds, setWorlds] = useState<World[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -43,7 +41,9 @@ export function WorldsPage({ onOpenWorld }: WorldsPageProps) {
     loadWorlds();
   }, [token]);
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  const handleChange = (
+    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
     const { name, value } = event.target;
     setForm((prev) => ({ ...prev, [name]: value }));
   };
@@ -68,19 +68,30 @@ export function WorldsPage({ onOpenWorld }: WorldsPageProps) {
     }
   };
 
+  const handleLogout = () => {
+    logout();
+    navigate("/", { replace: true });
+  };
+
+  const handleOpenWorld = (world: World) => {
+    navigate(`/worlds/${world.id}`, { state: { world } });
+  };
+
   return (
     <div className="dashboard">
-      <header className="dashboard__header">
+      <header className="dashboard__header dashboard__header--worlds">
         <div>
           <h1 className="title">Seus Mundos</h1>
-          <p className="subtitle">Gerencie e crie universos para explorar.</p>
+          <p className="subtitle">
+            Gerencie e crie universos para explorar narrativas únicas.
+          </p>
         </div>
-        <button className="secondary" type="button" onClick={logout}>
+        <button className="secondary" type="button" onClick={handleLogout}>
           Sair
         </button>
       </header>
 
-      <section className="card">
+      <section className="card card--highlight">
         <h2 className="section-title">Criar novo mundo</h2>
         <form className="form form--inline" onSubmit={handleCreate}>
           <label className="field">
@@ -114,10 +125,12 @@ export function WorldsPage({ onOpenWorld }: WorldsPageProps) {
       <section className="worlds-grid">
         {isLoading && <p className="loading">Carregando mundos...</p>}
         {!isLoading && !hasWorlds && (
-          <p className="empty">Nenhum mundo criado ainda. Comece criando um acima!</p>
+          <p className="empty">
+            Nenhum mundo criado ainda. Comece cadastrando um universo incrível!
+          </p>
         )}
         {worlds.map((world) => (
-          <article key={world.id} className="world-card">
+          <article key={world.id} className="world-card world-card--accent">
             <header>
               <h3>{world.name}</h3>
               <span className="world-date">
@@ -125,7 +138,7 @@ export function WorldsPage({ onOpenWorld }: WorldsPageProps) {
               </span>
             </header>
             <p>{world.description || "Sem descrição"}</p>
-            <button type="button" onClick={() => onOpenWorld(world)}>
+            <button type="button" onClick={() => handleOpenWorld(world)}>
               Entrar no mundo
             </button>
           </article>

--- a/src/router/RouteParamsContext.tsx
+++ b/src/router/RouteParamsContext.tsx
@@ -1,0 +1,23 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+type RouteParams = Record<string, string>;
+
+const RouteParamsContext = createContext<RouteParams>({});
+
+export function RouteParamsProvider({
+  params,
+  children,
+}: {
+  params: RouteParams;
+  children: ReactNode;
+}) {
+  return (
+    <RouteParamsContext.Provider value={params}>
+      {children}
+    </RouteParamsContext.Provider>
+  );
+}
+
+export function useRouteParams() {
+  return useContext(RouteParamsContext);
+}

--- a/src/router/RouterProvider.tsx
+++ b/src/router/RouterProvider.tsx
@@ -1,0 +1,82 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+type NavigateOptions = {
+  replace?: boolean;
+  state?: unknown;
+};
+
+type RouterContextValue = {
+  path: string;
+  navigate: (to: string, options?: NavigateOptions) => void;
+  state: unknown;
+};
+
+const RouterContext = createContext<RouterContextValue | undefined>(undefined);
+
+const getInitialPath = () =>
+  typeof window !== "undefined" ? window.location.pathname : "/";
+
+const getInitialState = () =>
+  typeof window !== "undefined" ? window.history.state?.state ?? null : null;
+
+export function RouterProvider({ children }: { children: ReactNode }) {
+  const [path, setPath] = useState<string>(() => getInitialPath());
+  const [locationState, setLocationState] = useState<unknown>(() =>
+    getInitialState()
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handlePopState = (event: PopStateEvent) => {
+      setPath(window.location.pathname);
+      setLocationState(event.state?.state ?? null);
+    };
+
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
+  }, []);
+
+  const navigate = useCallback((to: string, options?: NavigateOptions) => {
+    if (typeof window === "undefined") return;
+
+    const { replace = false, state } = options ?? {};
+    const nextState = state ?? null;
+
+    if (replace) {
+      window.history.replaceState({ state: nextState }, "", to);
+    } else {
+      window.history.pushState({ state: nextState }, "", to);
+    }
+
+    setPath(window.location.pathname);
+    setLocationState(nextState);
+  }, []);
+
+  const value = useMemo<RouterContextValue>(
+    () => ({
+      path,
+      navigate,
+      state: locationState,
+    }),
+    [path, navigate, locationState]
+  );
+
+  return <RouterContext.Provider value={value}>{children}</RouterContext.Provider>;
+}
+
+export function useRouter() {
+  const context = useContext(RouterContext);
+  if (!context) {
+    throw new Error("useRouter deve ser usado dentro de um RouterProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- add a lightweight router provider and update App to expose landing, login/register, worlds, and world canvas routes
- introduce a hero landing page and adjust the worlds dashboard styling for the new navigation flow
- refresh the canvas experience with guarded world fetching, clamped attribute text, and minimal icon buttons within modals

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3ca4fcee08325aa182b4a3ecdddf6